### PR TITLE
Restore PyQtWebEngine UI and add proprietary-codec build/install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ To get started with this project, you'll need to have Python 3.x installed on yo
    pip install PyQt5 PyQtWebEngine
    ```
 
+### Optional: Build PyQtWebEngine with Proprietary Codecs
+
+If you need proprietary codecs (for example, to enable additional media formats in the Reddit player or improve fullscreen media support), build PyQtWebEngine against a custom Qt build that enables proprietary codecs.
+
+> These scripts are heavy: they compile QtWebEngine and require significant disk space.
+
+#### Linux
+
+```bash
+./scripts/install_linux.sh
+```
+
+#### Windows (PowerShell)
+
+```powershell
+./scripts/install_windows.ps1
+```
+
+> Windows requires Visual Studio Build Tools and `jom` on PATH.
+
+The scripts will:
+
+1. Clone Qt 5.15.2 and build it with `-webengine-proprietary-codecs`.
+2. Clone PyQt5 and PyQtWebEngine (git mirrors).
+3. Build PyQt5 + PyQtWebEngine against the custom Qt build in a local virtual environment.
+
+If you already have a Qt build that enables proprietary codecs, update the script to point at your Qt install path.
+
 ## Usage
 
 To run the browser, execute the following command in your terminal or command prompt:

--- a/browser.py
+++ b/browser.py
@@ -1,18 +1,13 @@
-import sys
 import json
-import concurrent.futures
+import sys
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QTabWidget, QVBoxLayout, QWidget, QLineEdit, QAction, 
     QToolBar, QFileDialog, QMessageBox, QPushButton, QProgressBar, QStyleFactory, 
     QLabel, QHBoxLayout, QTabBar, QMenu)
 from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEngineProfile
-from PyQt5.QtCore import QUrl, Qt, pyqtSignal, QObject, QEventLoop, QTimer
+from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QKeySequence
 
-
-# Signal to update the bookmark menu from a background thread
-class UpdateBookmarkMenuSignal(QObject):
-    update_menu = pyqtSignal(list)
 
 class Browser(QMainWindow):
     def __init__(self):
@@ -76,10 +71,10 @@ class Browser(QMainWindow):
         self.nav_bar.addWidget(search_btn)
 
         # Fullscreen button
-        fullscreen_btn = QAction("Fullscreen", self)
-        fullscreen_btn.setStatusTip("Toggle Fullscreen Mode")
-        fullscreen_btn.triggered.connect(self.toggle_fullscreen)
-        self.nav_bar.addAction(fullscreen_btn)
+        self.fullscreen_action = QAction("Fullscreen", self)
+        self.fullscreen_action.setStatusTip("Toggle Fullscreen Mode")
+        self.fullscreen_action.triggered.connect(self.toggle_fullscreen)
+        self.nav_bar.addAction(self.fullscreen_action)
 
         # Progress bar
         self.progress_bar = QProgressBar()
@@ -94,11 +89,6 @@ class Browser(QMainWindow):
 
         # Mode toggle button
         self.mode_toggle_btn = QAction("Switch to Dark Mode", self)
-        self.mode_toggle_btn.setStatusTip("Toggle Dark/Light Mode")
-        self.mode_toggle_btn.triggered.connect(self.toggle_dark_mode)
-        self.nav_bar.addAction(self.mode_toggle_btn)
-
-        # Menu Bar
         self.mode_toggle_btn.setStatusTip("Toggle Dark/Light Mode")
         self.mode_toggle_btn.triggered.connect(self.toggle_dark_mode)
         self.nav_bar.addAction(self.mode_toggle_btn)
@@ -135,13 +125,6 @@ class Browser(QMainWindow):
         self.add_new_tab()
         self.navigate_to_url("https://www.google.com")
 
-        # Create a signal instance for updating the bookmark menu
-        self.update_menu_signal = UpdateBookmarkMenuSignal()
-        self.update_menu_signal.update_menu.connect(self.update_bookmark_menu_from_signal)
-
-        # Create a thread pool executor
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
-
     def apply_dark_mode(self):
         dark_mode_qss = """
         /* Dark mode styles */
@@ -166,10 +149,10 @@ class Browser(QMainWindow):
     def toggle_fullscreen(self):
         if self.is_fullscreen:
             self.showNormal()
-            self.fullscreen_btn.setText("Fullscreen")
+            self.fullscreen_action.setText("Fullscreen")
         else:
             self.showFullScreen()
-            self.fullscreen_btn.setText("Exit Fullscreen")
+            self.fullscreen_action.setText("Exit Fullscreen")
         self.is_fullscreen = not self.is_fullscreen
 
     def add_new_tab(self, url="https://www.google.com"):
@@ -202,10 +185,11 @@ class Browser(QMainWindow):
         custom_tab_layout = QHBoxLayout(custom_tab)
         custom_tab_layout.setContentsMargins(0, 0, 0, 0)
         title_label = QLabel("New Tab")
+        title_label.setObjectName("tab-title")
         custom_tab_layout.addWidget(title_label)
         close_button = QPushButton("✕")
         close_button.setMaximumSize(16, 16)
-        close_button.clicked.connect(lambda: self.close_tab(index))
+        close_button.clicked.connect(lambda _, tab=tab: self.close_tab(self.tabs.indexOf(tab)))
         custom_tab_layout.addWidget(close_button)
     
         # Set the custom tab widget
@@ -225,7 +209,7 @@ class Browser(QMainWindow):
         if index != -1:
             custom_tab = self.tabs.tabBar().tabButton(index, QTabBar.RightSide)
             if custom_tab:
-                title_label = custom_tab.findChild(QLabel, "")
+                title_label = custom_tab.findChild(QLabel, "tab-title")
                 if title_label:
                     title_label.setText(title)
 
@@ -287,8 +271,7 @@ class Browser(QMainWindow):
             self.bookmark_menu.addAction(bookmark_action)
 
     def update_bookmark_menu(self):
-        # Offload the bookmark menu update to a background thread
-        self.executor.submit(self.update_bookmark_menu_from_signal, self.bookmarks)
+        self.update_bookmark_menu_from_signal(self.bookmarks)
 
     def navigate_bookmark(self):
         action = self.sender()
@@ -298,26 +281,27 @@ class Browser(QMainWindow):
     def load_bookmarks(self):
         file_name, _ = QFileDialog.getOpenFileName(self, "Open Bookmark File", "", "JSON Files (*.json)")
         if file_name:
-            self.executor.submit(self._load_bookmarks_from_file, file_name)
+            self._load_bookmarks_from_file(file_name)
 
     def _load_bookmarks_from_file(self, file_name):
         try:
             with open(file_name, "r") as file:
-                QMetaObject.invokeMethod(self, "critical_error", Qt.QueuedConnection, Q_ARG(str, f"Failed to load bookmarks: {e}"))
-        except:
-            pass
+                self.bookmarks = json.load(file)
+            self.update_bookmark_menu()
+        except Exception as error:
+            self.critical_error(f"Failed to load bookmarks: {error}")
 
     def save_bookmarks(self):
         file_name, _ = QFileDialog.getSaveFileName(self, "Save Bookmark File", "", "JSON Files (*.json)")
         if file_name:
-            self.executor.submit(self._save_bookmarks_to_file, file_name)
+            self._save_bookmarks_to_file(file_name)
 
     def _save_bookmarks_to_file(self, file_name):
         try:
             with open(file_name, "w") as file:
                 json.dump(self.bookmarks, file, indent=4)
-        except Exception as e:
-            QMetaObject.invokeMethod(self, "critical_error", Qt.QueuedConnection, Q_ARG(str, f"Failed to save bookmarks: {e}"))
+        except Exception as error:
+            self.critical_error(f"Failed to save bookmarks: {error}")
 
     def current_browser(self):
         current_index = self.tabs.currentIndex()

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${ROOT_DIR}/.build"
+QT_DIR="${WORK_DIR}/qt5"
+PYQT_DIR="${WORK_DIR}/pyqt5"
+PYQT_WEBENGINE_DIR="${WORK_DIR}/pyqtwebengine"
+QT_INSTALL_DIR="${WORK_DIR}/qt-install"
+
+mkdir -p "${WORK_DIR}"
+
+cat <<'BANNER'
+Borgor Browser - Linux setup for PyQtWebEngine with proprietary codecs
+This script builds QtWebEngine with proprietary codecs enabled and then builds
+PyQt5 + PyQtWebEngine against that Qt build.
+
+Requirements:
+  - build tools: gcc/g++, make, ninja (recommended), python3
+  - dependencies for QtWebEngine (see Qt docs)
+  - plenty of disk space (QtWebEngine builds are large)
+BANNER
+
+echo ":: Ensuring build dependencies (Ubuntu/Debian example)"
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y build-essential python3 python3-venv ninja-build git \
+    libgl1-mesa-dev libxcb-xinerama0 libxkbcommon-dev libxrender-dev \
+    libxrandr-dev libxcomposite-dev libxdamage-dev libxfixes-dev \
+    libxi-dev libx11-xcb-dev libxcursor-dev libxext-dev libxss-dev \
+    libxtst-dev libnss3-dev libasound2-dev libdbus-1-dev libdrm-dev
+fi
+
+if [ ! -d "${QT_DIR}" ]; then
+  echo ":: Cloning Qt5"
+  git clone https://code.qt.io/qt/qt5.git "${QT_DIR}"
+  (
+    cd "${QT_DIR}"
+    git checkout 5.15.2
+    ./init-repository --module-subset=qtbase,qtdeclarative,qtwebengine,qtwebchannel,qtwebsockets,qttools
+  )
+fi
+
+echo ":: Configuring Qt with proprietary codecs"
+(
+  cd "${QT_DIR}"
+  ./configure \
+    -opensource -confirm-license -release -nomake examples -nomake tests \
+    -prefix "${QT_INSTALL_DIR}" \
+    -webengine-proprietary-codecs -webengine-ffmpeg
+  make -j"$(nproc)"
+  make install
+)
+
+echo ":: Setting up Python virtual environment"
+python3 -m venv "${WORK_DIR}/venv"
+# shellcheck disable=SC1091
+source "${WORK_DIR}/venv/bin/activate"
+
+pip install --upgrade pip setuptools wheel sip
+
+if [ ! -d "${PYQT_DIR}" ]; then
+  echo ":: Cloning PyQt5"
+  git clone https://github.com/baoboa/pyqt5.git "${PYQT_DIR}"
+fi
+
+if [ ! -d "${PYQT_WEBENGINE_DIR}" ]; then
+  echo ":: Cloning PyQtWebEngine"
+  git clone https://github.com/baoboa/pyqtwebengine.git "${PYQT_WEBENGINE_DIR}"
+fi
+
+echo ":: Building PyQt5"
+(
+  cd "${PYQT_DIR}"
+  python3 configure.py --qmake "${QT_INSTALL_DIR}/bin/qmake" --confirm-license
+  make -j"$(nproc)"
+  make install
+)
+
+echo ":: Building PyQtWebEngine"
+(
+  cd "${PYQT_WEBENGINE_DIR}"
+  python3 configure.py --qmake "${QT_INSTALL_DIR}/bin/qmake" --confirm-license
+  make -j"$(nproc)"
+  make install
+)
+
+echo ":: Done. Activate the venv and run: python browser.py"

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,0 +1,67 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path "${PSScriptRoot}\.."
+$workDir = Join-Path $rootDir ".build"
+$qtDir = Join-Path $workDir "qt5"
+$pyqtDir = Join-Path $workDir "pyqt5"
+$pyqtWebEngineDir = Join-Path $workDir "pyqtwebengine"
+$qtInstallDir = Join-Path $workDir "qt-install"
+
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+
+Write-Host "Borgor Browser - Windows setup for PyQtWebEngine with proprietary codecs"
+Write-Host "This script builds QtWebEngine with proprietary codecs enabled and then builds"
+Write-Host "PyQt5 + PyQtWebEngine against that Qt build."
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  throw "git is required on PATH"
+}
+
+if (-not (Test-Path $qtDir)) {
+  Write-Host ":: Cloning Qt5"
+  git clone https://code.qt.io/qt/qt5.git $qtDir
+  Push-Location $qtDir
+  git checkout 5.15.2
+  .\init-repository --module-subset=qtbase,qtdeclarative,qtwebengine,qtwebchannel,qtwebsockets,qttools
+  Pop-Location
+}
+
+Write-Host ":: Configuring Qt with proprietary codecs"
+Push-Location $qtDir
+.\configure.bat -opensource -confirm-license -release -nomake examples -nomake tests `
+  -prefix $qtInstallDir -webengine-proprietary-codecs -webengine-ffmpeg
+jom
+jom install
+Pop-Location
+
+Write-Host ":: Setting up Python virtual environment"
+python -m venv (Join-Path $workDir "venv")
+& (Join-Path $workDir "venv\Scripts\activate.ps1")
+
+pip install --upgrade pip setuptools wheel sip
+
+if (-not (Test-Path $pyqtDir)) {
+  Write-Host ":: Cloning PyQt5"
+  git clone https://github.com/baoboa/pyqt5.git $pyqtDir
+}
+
+if (-not (Test-Path $pyqtWebEngineDir)) {
+  Write-Host ":: Cloning PyQtWebEngine"
+  git clone https://github.com/baoboa/pyqtwebengine.git $pyqtWebEngineDir
+}
+
+Write-Host ":: Building PyQt5"
+Push-Location $pyqtDir
+python configure.py --qmake (Join-Path $qtInstallDir "bin\qmake.exe") --confirm-license
+jom
+jom install
+Pop-Location
+
+Write-Host ":: Building PyQtWebEngine"
+Push-Location $pyqtWebEngineDir
+python configure.py --qmake (Join-Path $qtInstallDir "bin\qmake.exe") --confirm-license
+jom
+jom install
+Pop-Location
+
+Write-Host ":: Done. Activate the venv and run: python browser.py"


### PR DESCRIPTION
### Motivation

- Revert the Playwright-based experiment and restore the original PyQt5 + PyQtWebEngine UI to recover fullscreen and Reddit media player behavior that requires native WebEngine support.
- Provide an automated way to produce a PyQtWebEngine build that includes proprietary codecs so media playback/fullscreen works across platforms where default wheels lack those codecs.
- Make the codec-build process reproducible on both Linux and Windows by adding platform-specific automation and documenting the steps.

### Description

- Restored a PyQt5/PyQtWebEngine-based browser implementation in `browser.py` with UI fixes including a dedicated `fullscreen_action`, improved tab title lookup (`objectName='tab-title'`), and corrected bookmark load/save logic (synchronous JSON load/save and error reporting via `critical_error`).
- Removed unused threading/executor and signal scaffolding and simplified bookmark menu updates by calling `update_bookmark_menu_from_signal` directly.
- Added build/install automation scripts `scripts/install_linux.sh` and `scripts/install_windows.ps1` that clone Qt 5.15.2, configure Qt with `-webengine-proprietary-codecs` (`-webengine-ffmpeg`), build and install Qt, then build PyQt5 and PyQtWebEngine against that custom Qt install inside a local virtual environment.
- Documented the optional proprietary codec build flow and prerequisites in `README.md`, and made the Linux script executable (`chmod +x scripts/install_linux.sh`).

### Testing

- No automated tests were run as part of this change; the added build scripts and GUI changes require manual validation on target platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ecc8aedd08331a2b5732e8555e36b)